### PR TITLE
Fix the Load() memory leak

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -95,8 +95,8 @@ loader_error_msg(perl_yaml_loader_t *loader, char *problem)
     )
         msg = form("%s, line: %d, column: %d\n",
             msg,
-            loader->parser.problem_mark.line + 1,
-            loader->parser.problem_mark.column + 1
+            (int)loader->parser.problem_mark.line + 1,
+            (int)loader->parser.problem_mark.column + 1
         );
     else
         msg = form("%s\n", msg);
@@ -104,8 +104,8 @@ loader_error_msg(perl_yaml_loader_t *loader, char *problem)
         msg = form("%s%s at line: %d, column: %d\n",
             msg,
             loader->parser.context,
-            loader->parser.context_mark.line + 1,
-            loader->parser.context_mark.column + 1
+            (int)loader->parser.context_mark.line + 1,
+            (int)loader->parser.context_mark.column + 1
         );
 
     return msg;


### PR DESCRIPTION
I adjusted the patch in https://rt.cpan.org/Ticket/Display.html?id=46172 for the latest version. I'm processing a lot of YAML files in one goal and this makes a difference in a couple orders of magnitude in the memory footprint.
