### PR TITLE
added "config.h" because <config.h> wasn't found

### DIFF
--- a/LibYAML/yaml_private.h
+++ b/LibYAML/yaml_private.h
@@ -1,6 +1,7 @@
 
 #if HAVE_CONFIG_H
 #include <config.h>
+#include "config.h"
 #endif
 
 #include <yaml.h>


### PR DESCRIPTION
Was receiving this error, and so I included "config.h" in yaml_private.h

```
user@user-System-Product-Name:/tmp/yaml-libyaml-pm/YAML-LibYAML-0.41$ make
cp lib/YAML/XS.pm blib/lib/YAML/XS.pm
cp lib/YAML/LibYAML.pm blib/lib/YAML/LibYAML.pm
make[1]: Entering directory `/tmp/yaml-libyaml-pm/YAML-LibYAML-0.41/LibYAML'
cp lib/YAML/XS/LibYAML.pm ../blib/lib/YAML/XS/LibYAML.pm
cc -c  -I. -fno-strict-aliasing -pipe -fstack-protector -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2   -DVERSION=\"\" -DXS_VERSION=\"\" -fPIC "-I/home/user/perl5/perlbrew/perls/perl-5.18.2/lib/5.18.2/x86_64-linux/CORE"  -DHAVE_CONFIG_H api.c
api.c: In function 'yaml_get_version_string':
api.c:11:12: error: 'YAML_VERSION_STRING' undeclared (first use in this function)
api.c:11:12: note: each undeclared identifier is reported only once for each function it appears in
api.c: In function 'yaml_get_version':
api.c:21:14: error: 'YAML_VERSION_MAJOR' undeclared (first use in this function)
api.c:22:14: error: 'YAML_VERSION_MINOR' undeclared (first use in this function)
api.c:23:14: error: 'YAML_VERSION_PATCH' undeclared (first use in this function)
make[1]: *** [api.o] Error 1
make[1]: Leaving directory `/tmp/yaml-libyaml-pm/YAML-LibYAML-0.41/LibYAML'
make: *** [subdirs] Error 2
```
