### PR TITLE
state main_module in dist.ini (RT#75404)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,6 +3,7 @@ author           = Ingy döt Net <ingy@cpan.org>
 license          = Perl_5
 copyright_holder = Ingy döt Net
 version          = 0.41
+main_module      = lib/YAML/XS.pm
  
 [NextRelease]
 [@Git]


### PR DESCRIPTION
Hi,
this should at least put abstract in order, which is now being scraped from LibYAML.pm instead of XS.pm (initially reported empty in [this ticket](https://rt.cpan.org/Public/Bug/Display.html?id=75404))

sromanov
