### PR TITLE
add LiteralMultilineStrings config variable

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -506,6 +506,10 @@ set_dumper_options(perl_yaml_dumper_t *dumper)
         ((gv = gv_fetchpv("YAML::XS::QuoteNumericStrings", TRUE, SVt_PV)) &&
         SvTRUE(GvSV(gv)))
     );
+    dumper->literal_multiline_strings = (
+        ((gv = gv_fetchpv("YAML::XS::LiteralMultilineStrings", TRUE, SVt_PV)) &&
+        SvTRUE(GvSV(gv)))
+    );
     /* dumper->emitter.open_ended = 1;
      */
 }
@@ -898,6 +902,10 @@ dump_scalar(perl_yaml_dumper_t *dumper, SV *node, yaml_char_t *tag)
 
         /* get string and length out of utf8 */
         string = SvPVutf8(utf8sv, string_len);
+
+        /* check for embedded newlines and change style accordingly */
+        if(dumper->literal_multiline_strings && strchr(string, '\n'))
+           style = YAML_LITERAL_SCALAR_STYLE;
         }
     }
     yaml_scalar_event_initialize(

--- a/LibYAML/perl_libyaml.h
+++ b/LibYAML/perl_libyaml.h
@@ -38,6 +38,7 @@ typedef struct {
     HV *shadows;
     int dump_code;
     int quote_number_strings;
+    int literal_multiline_strings;
 } perl_yaml_dumper_t;
 
 static SV *


### PR DESCRIPTION
I switched from pure Perl YAML to YAML::XS a while ago for various reasons, but one thing that has bothered me is the lack of scalar-style heuristics that can choose between block and flow style strings (the way you have it in pure Perl YAML.pm). Our YAML configs have relatively many multi-line documents and YAML::XS' default single-quoted flow style looks just nasty with its empty lines in-between all the text lines. Therefore I added $YAML::XS::LiteralMultilineStrings that switches to YAML_LITERAL_SCALAR_STYLE when there's a newline in the string.
I was thinking of adding a variable for the default style as well so as to be able to switch to PP YAML's double-quote style for short multiline strings but wanted to see first whether there's any chance of getting that stuff onto CPAN.