### PR TITLE
Add heuristic for multiline literals

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -891,13 +891,16 @@ dump_scalar(perl_yaml_dumper_t *dumper, SV *node, yaml_char_t *tag)
             ( dumper->quote_number_strings && !SvNIOK(node) && looks_like_number(node) )
         ) {
             style = YAML_SINGLE_QUOTED_SCALAR_STYLE;
-        }
-        if (!SvUTF8(node)) {
-        /* copy to new SV and promote to utf8 */
-        SV *utf8sv = sv_mortalcopy(node);
+        } else {
+            if (!SvUTF8(node)) {
+            /* copy to new SV and promote to utf8 */
+            SV *utf8sv = sv_mortalcopy(node);
 
-        /* get string and length out of utf8 */
-        string = SvPVutf8(utf8sv, string_len);
+            /* get string and length out of utf8 */
+            string = SvPVutf8(utf8sv, string_len);
+            }
+            if(strchr(string, '\n'))
+               style = (string_len > 30) ? YAML_LITERAL_SCALAR_STYLE : YAML_DOUBLE_QUOTED_SCALAR_STYLE;
         }
     }
     yaml_scalar_event_initialize(


### PR DESCRIPTION
Strings with embedded newlines get dumped in double quoted style if they are at
most 30 characters long, otherwise in multiline literal style.

I think I somewhat screwed up the indentation because I didn't get the style :)
Also there's a small optimization that avoids making a copy of the string if its UTF8 flag is unset but it is empty, "true" etc. where by definition it doesn't make a difference. As I didn't get how the test suite works either I couldn't really verify it or update the tests but it seems to work the same as YAML.pm now.