### PR TITLE
determine if argument is a filehandle or filename with Ref::Util

### DIFF
--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -17,11 +17,12 @@ use base 'Exporter';
 $YAML::XS::QuoteNumericStrings = 1;
 
 use YAML::XS::LibYAML qw(Load Dump);
+use Ref::Util qw/ is_globref is_ioref /;
 
 sub DumpFile {
     my $OUT;
     my $filename = shift;
-    if (defined fileno($filename)) {
+    if (is_globref($filename) || is_ioref($filename)) {
         $OUT = $filename;
     }
     else {
@@ -39,7 +40,7 @@ sub DumpFile {
 sub LoadFile {
     my $IN;
     my $filename = shift;
-    if (defined fileno($filename)) {
+    if (is_globref($filename) || is_ioref($filename)) {
         $IN = $filename;
     }
     else {

--- a/test/path-class.t
+++ b/test/path-class.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use t::TestYAML tests => 2;
+use YAML::XS qw/ DumpFile LoadFile /;
+
+my $pc = eval "use Path::Class; 1";
+
+my $file;
+
+SKIP: {
+    skip "Path::Class need for this test", 2 unless $pc;
+
+    my $data = {
+        foo => "boo",
+    };
+    $file = file("t", "path-class-$$.yaml");
+    DumpFile($file, $data);
+    ok -f $file, "Path::Class $file exists";
+
+    my $data2 = LoadFile($file);
+    is_deeply($data, $data2, "Path::Class roundtrip works");
+}
+
+END {
+    unlink $file if defined $file;
+}


### PR DESCRIPTION
So, another pull request for issue #38

This uses Ref::Util. Adds a dependency, but looks like the cleanest solution.
