### PR TITLE
Fix memory leak when Load() fails

### DIFF
--- a/LibYAML/perl_libyaml.h
+++ b/LibYAML/perl_libyaml.h
@@ -7,6 +7,7 @@
 
 #include "EXTERN.h"
 #include "perl.h"
+#define NO_XSLOCKS
 #include "XSUB.h"
 #define NEED_newRV_noinc
 #define NEED_sv_2pv_nolen

--- a/note/memleak.pl
+++ b/note/memleak.pl
@@ -1,0 +1,37 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+use YAML::XS qw/ Load /;
+
+sub yaml {
+    my ($str) = @_;
+
+    eval {
+        my $obj = Load($str);
+    };
+    if ($@) {
+        say "EVAL_ERROR: $@\nfailed to convert YAML string: $str";
+    }
+}
+
+my $str = do { local $/; <DATA> };
+
+my $count = $ARGV[0] || 1000;
+my $sleep = $ARGV[1] || 3;
+for my $i (0 .. $count) {
+    say "== Loop $i";
+    select undef, undef, undef, 0.005;
+    yaml($str);
+
+    if ($i and not $i % 50) {
+        say "Process size:";
+        system("ps -o pid,vsz --pid $$");
+        select undef, undef, undef, $sleep;
+    }
+}
+
+__DATA__
+---
+foo: bar
+aaa


### PR DESCRIPTION
See #34

This fixes a big memory leak, calling `yaml_parser_delete` when
loading fails, but there are still other leaks remaining.

I really would appreciate if anyone with more XS foo could review this, this is my first perl XS pull request, and I have very little C experience.