### PR TITLE
Clone node before analyzing (fix #32)

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -895,21 +895,22 @@ dump_scalar(perl_yaml_dumper_t *dumper, SV *node, yaml_char_t *tag)
         style = YAML_PLAIN_SCALAR_STYLE;
     }
     else {
-        string = SvPV_nomg(node, string_len);
+        SV *node_clone = sv_mortalcopy(node);
+        string = SvPV_nomg(node_clone, string_len);
         if (
             (string_len == 0) ||
             strEQ(string, "~") ||
             strEQ(string, "true") ||
             strEQ(string, "false") ||
             strEQ(string, "null") ||
-            (SvTYPE(node) >= SVt_PVGV) ||
-            ( dumper->quote_number_strings && !SvNIOK(node) && looks_like_number(node) )
+            (SvTYPE(node_clone) >= SVt_PVGV) ||
+            ( dumper->quote_number_strings && !SvNIOK(node_clone) && looks_like_number(node_clone) )
         ) {
             style = YAML_SINGLE_QUOTED_SCALAR_STYLE;
         } else {
-            if (!SvUTF8(node)) {
+            if (!SvUTF8(node_clone)) {
             /* copy to new SV and promote to utf8 */
-            SV *utf8sv = sv_mortalcopy(node);
+            SV *utf8sv = sv_mortalcopy(node_clone);
 
             /* get string and length out of utf8 */
             string = SvPVutf8(utf8sv, string_len);

--- a/test/tied.t
+++ b/test/tied.t
@@ -14,9 +14,9 @@ use Tie::Hash;
 
 my $yaml1 = <<'...';
 ---
-- 'foo'
-- 'bar'
-- 'baz'
+- foo
+- bar
+- baz
 ...
 
 {
@@ -29,9 +29,9 @@ my $yaml1 = <<'...';
 
 my $yaml2 = <<'...';
 ---
-bar: 'bar'
-baz: 'baz'
-foo: 'foo'
+bar: bar
+baz: baz
+foo: foo
 ...
 
 {


### PR DESCRIPTION
It looks like SvPV_nomg adds the string representation for the number
and creates side effects.

    perl -MDevel::Peek -MYAML::XS -e \
    '$x = 123; print Devel::Peek::Dump($x); YAML::XS::Dump($x); print Devel::Peek::Dump($x)'

This breaks tied tests, but it looks like the test was invalid, since
generating bare values should be fine there.