### PR TITLE
Support JSON::PP::Boolean

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -128,18 +128,22 @@ Load(SV *yaml_sv)
 
     GV *gv = gv_fetchpv("YAML::XS::Boolean", FALSE, SVt_PV);
     char* boolean = "";
-    if (SvTRUE(GvSV(gv))) {
-        boolean = SvPV_nolen(GvSV(gv));
-    }
     loader.load_bool_jsonpp = 0;
     loader.load_bool_boolean = 0;
-    if (strEQ(boolean, "JSON::PP")) {
-        loader.load_bool_jsonpp = 1;
-        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
-    }
-    else if (strEQ(boolean, "boolean")) {
-        loader.load_bool_boolean = 1;
-        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("boolean", 0), Nullsv);
+    if (SvTRUE(GvSV(gv))) {
+        boolean = SvPV_nolen(GvSV(gv));
+        if (strEQ(boolean, "JSON::PP")) {
+            loader.load_bool_jsonpp = 1;
+            load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
+        }
+        else if (strEQ(boolean, "boolean")) {
+            loader.load_bool_boolean = 1;
+            load_module(PERL_LOADMOD_NOIMPORT, newSVpv("boolean", 0), Nullsv);
+        }
+        else {
+            croak("%s",
+                "$YAML::XS::Boolean only accepts 'JSON::PP', 'boolean' or a false value");
+        }
     }
 
     yaml_str = (const unsigned char *)SvPV_const(yaml_sv, yaml_len);
@@ -575,14 +579,18 @@ set_dumper_options(perl_yaml_dumper_t *dumper)
     dumper->dump_bool_boolean = 0;
     if (SvTRUE(GvSV(gv))) {
         boolean = SvPV_nolen(GvSV(gv));
-    }
-    if (strEQ(boolean, "JSON::PP")) {
-        dumper->dump_bool_jsonpp = 1;
-        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
-    }
-    else if (strEQ(boolean, "boolean")) {
-        dumper->dump_bool_boolean = 1;
-        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("boolean", 0), Nullsv);
+        if (strEQ(boolean, "JSON::PP")) {
+            dumper->dump_bool_jsonpp = 1;
+            load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
+        }
+        else if (strEQ(boolean, "boolean")) {
+            dumper->dump_bool_boolean = 1;
+            load_module(PERL_LOADMOD_NOIMPORT, newSVpv("boolean", 0), Nullsv);
+        }
+        else {
+            croak("%s",
+                "$YAML::XS::Boolean only accepts 'JSON::PP', 'boolean' or a false value");
+        }
     }
 
     /* dumper->emitter.open_ended = 1;

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -128,7 +128,7 @@ Load(SV *yaml_sv)
 
     GV *gv;
     loader.load_bool = (
-        (gv = gv_fetchpv("YAML::XS::Booleans", TRUE, SVt_PV)) &&
+        (gv = gv_fetchpv("YAML::XS::Boolean", TRUE, SVt_PV)) &&
         SvTRUE(GvSV(gv))
     );
     if (loader.load_bool) {
@@ -551,7 +551,7 @@ set_dumper_options(perl_yaml_dumper_t *dumper)
     );
 
     dumper->dump_bool = (
-        (gv = gv_fetchpv("YAML::XS::Booleans", TRUE, SVt_PV)) &&
+        (gv = gv_fetchpv("YAML::XS::Boolean", TRUE, SVt_PV)) &&
         SvTRUE(GvSV(gv))
     );
     if (dumper->dump_bool) {

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -131,6 +131,9 @@ Load(SV *yaml_sv)
         (gv = gv_fetchpv("YAML::XS::Booleans", TRUE, SVt_PV)) &&
         SvTRUE(GvSV(gv))
     );
+    if (loader.load_bool) {
+        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
+    }
 
     yaml_str = (const unsigned char *)SvPV_const(yaml_sv, yaml_len);
 
@@ -551,6 +554,9 @@ set_dumper_options(perl_yaml_dumper_t *dumper)
         (gv = gv_fetchpv("YAML::XS::Booleans", TRUE, SVt_PV)) &&
         SvTRUE(GvSV(gv))
     );
+    if (dumper->dump_bool) {
+        load_module(PERL_LOADMOD_NOIMPORT, newSVpv("JSON::PP", 0), Nullsv);
+    }
 
     /* dumper->emitter.open_ended = 1;
      */

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -768,12 +768,13 @@ dump_node(perl_yaml_dumper_t *dumper, SV *node)
                 dump_scalar(dumper, node, tag);
             }
             else {
+                class = sv_reftype(rnode, TRUE);
                 if (
                         dumper->dump_bool_jsonpp
-                        && strEQ(sv_reftype(rnode, TRUE), "JSON::PP::Boolean")
+                        && strEQ(class, "JSON::PP::Boolean")
                     ||
                         dumper->dump_bool_boolean
-                        && strEQ(sv_reftype(rnode, TRUE), "boolean")
+                        && strEQ(class, "boolean")
                     ) {
                     if (SvIV(node)) {
                         dump_scalar(dumper, &PL_sv_yes, NULL);
@@ -785,7 +786,7 @@ dump_node(perl_yaml_dumper_t *dumper, SV *node)
                 else {
                     tag = (yaml_char_t *)form(
                         TAG_PERL_PREFIX "scalar:%s",
-                        sv_reftype(rnode, TRUE)
+                        class
                     );
                     node = rnode;
                     dump_scalar(dumper, node, tag);

--- a/LibYAML/perl_libyaml.h
+++ b/LibYAML/perl_libyaml.h
@@ -29,6 +29,7 @@ typedef struct {
     yaml_event_t event;
     HV *anchors;
     int load_code;
+    int load_bool;
     int document;
 } perl_yaml_loader_t;
 
@@ -38,6 +39,7 @@ typedef struct {
     HV *anchors;
     HV *shadows;
     int dump_code;
+    int dump_bool;
     int quote_number_strings;
 } perl_yaml_dumper_t;
 

--- a/LibYAML/perl_libyaml.h
+++ b/LibYAML/perl_libyaml.h
@@ -29,7 +29,8 @@ typedef struct {
     yaml_event_t event;
     HV *anchors;
     int load_code;
-    int load_bool;
+    int load_bool_jsonpp;
+    int load_bool_boolean;
     int document;
 } perl_yaml_loader_t;
 
@@ -39,7 +40,8 @@ typedef struct {
     HV *anchors;
     HV *shadows;
     int dump_code;
-    int dump_bool;
+    int dump_bool_jsonpp;
+    int dump_bool_boolean;
     int quote_number_strings;
 } perl_yaml_dumper_t;
 

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -49,10 +49,9 @@ functions. Only `Load` and `Dump` are exported by default.
   loaded as JSON::PP::Boolean objects. Those objects will be dumped again
   as plain "true" or "false".
 
-  Note that you have to load JSON::PP yourself.
+  It will try to load JSON::PP and die if it can't be loaded.
 
       local $YAML::XS::Booleans = 1;
-      use JSON::PP;
       my $bool = 0;
       Dump { bool => $bool ? JSON::PP::true : JSON::PP::false ) };
       # ---

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -43,7 +43,7 @@ functions. Only `Load` and `Dump` are exported by default.
   This ensures leading that things like leading zeros and other formatting are
   preserved.
 
-- `$YAML::XS::Booleans`
+- `$YAML::XS::Boolean`
 
   When true (default is false) the plain strings "true" and "false" will be
   loaded as JSON::PP::Boolean objects. Those objects will be dumped again
@@ -51,7 +51,7 @@ functions. Only `Load` and `Dump` are exported by default.
 
   It will try to load JSON::PP and die if it can't be loaded.
 
-      local $YAML::XS::Booleans = 1;
+      local $YAML::XS::Boolean = 1;
       my $bool = 0;
       Dump { bool => $bool ? JSON::PP::true : JSON::PP::false ) };
       # ---

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -43,6 +43,21 @@ functions. Only `Load` and `Dump` are exported by default.
   This ensures leading that things like leading zeros and other formatting are
   preserved.
 
+- `$YAML::XS::Booleans`
+
+  When true (default is false) the plain strings "true" and "false" will be
+  loaded as JSON::PP::Boolean objects. Those objects will be dumped again
+  as plain "true" or "false".
+
+  Note that you have to load JSON::PP yourself.
+
+      local $YAML::XS::Booleans = 1;
+      use JSON::PP;
+      my $bool = 0;
+      Dump { bool => $bool ? JSON::PP::true : JSON::PP::false ) };
+      # ---
+      # bool: false
+
 = Using YAML::XS with Unicode
 
 Handling unicode properly in Perl can be a pain. YAML::XS only deals with

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -43,15 +43,15 @@ functions. Only `Load` and `Dump` are exported by default.
   This ensures leading that things like leading zeros and other formatting are
   preserved.
 
-- `$YAML::XS::Boolean`
+- `$YAML::XS::Boolean` (since v0.67)
 
-  When true (default is false) the plain strings "true" and "false" will be
-  loaded as JSON::PP::Boolean objects. Those objects will be dumped again
-  as plain "true" or "false".
+  When set to C<"JSON::PP"> or C<"boolean"> the plain (unquoted) strings "true"
+  and "false" will be loaded as C<JSON::PP::Boolean> or C<boolean.pm> objects.
+  Those objects will be dumped again as plain "true" or "false".
 
-  It will try to load JSON::PP and die if it can't be loaded.
+  It will try to load L<JSON::PP> or L<boolean> and die if it can't be loaded.
 
-      local $YAML::XS::Boolean = 1;
+      local $YAML::XS::Boolean = "JSON::PP"; # or "boolean"
       my $bool = 0;
       Dump { bool => $bool ? JSON::PP::true : JSON::PP::false ) };
       # ---

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -45,17 +45,37 @@ functions. Only `Load` and `Dump` are exported by default.
 
 - `$YAML::XS::Boolean` (since v0.67)
 
-  When set to C<"JSON::PP"> or C<"boolean"> the plain (unquoted) strings "true"
-  and "false" will be loaded as C<JSON::PP::Boolean> or C<boolean.pm> objects.
+  Default is undef.
+
+  When set to `"JSON::PP"` or `"boolean"`, the plain (unquoted) strings `true`
+  and `false` will be loaded as `JSON::PP::Boolean` or `boolean.pm` objects.
   Those objects will be dumped again as plain "true" or "false".
 
   It will try to load L<JSON::PP> or L<boolean> and die if it can't be loaded.
 
+  With that it's possible to add new "real" booleans to a data structure:
+
       local $YAML::XS::Boolean = "JSON::PP"; # or "boolean"
-      my $bool = 0;
-      Dump { bool => $bool ? JSON::PP::true : JSON::PP::false ) };
-      # ---
-      # bool: false
+      my $data = Load("booltrue: true");
+      $data->{boolfalse} = JSON::PP::false;
+      my $yaml = Dump($data);
+      # boolfalse: false
+      # booltrue: true
+
+  It also allows to let booleans survive when loading YAML via YAML::XS and
+  encode it in JSON via one of the various JSON encoders, which mostly support
+  JSON::PP booleans.
+
+  Please note that JSON::PP::Booolean and boolean.pm behave a bit differently.
+  Ideally you should only use them in boolean context.
+
+  If not set, booleans are loaded as special perl variables `PL_sv_yes` and
+  `PL_sv_no`, which have the disadvantage that they are readonly, and you can't
+  add those to an existing data structure with pure perl.
+
+  If you simply need to load "perl booleans" that are true or false in boolean
+  context, you will be fine with the default setting.
+
 
 = Using YAML::XS with Unicode
 

--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -10,7 +10,7 @@ use base 'Exporter';
 %YAML::XS::EXPORT_TAGS = (
     all => [qw(Dump Load LoadFile DumpFile)],
 );
-our ($UseCode, $DumpCode, $LoadCode, $Booleans);
+our ($UseCode, $DumpCode, $LoadCode, $Boolean);
 # $YAML::XS::UseCode = 0;
 # $YAML::XS::DumpCode = 0;
 # $YAML::XS::LoadCode = 0;

--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -10,7 +10,7 @@ use base 'Exporter';
 %YAML::XS::EXPORT_TAGS = (
     all => [qw(Dump Load LoadFile DumpFile)],
 );
-our ($UseCode, $DumpCode, $LoadCode);
+our ($UseCode, $DumpCode, $LoadCode, $Booleans);
 # $YAML::XS::UseCode = 0;
 # $YAML::XS::DumpCode = 0;
 # $YAML::XS::LoadCode = 0;

--- a/test/boolean-boolean.t
+++ b/test/boolean-boolean.t
@@ -9,6 +9,7 @@ my $yaml = <<'...';
 boolfalse: false
 booltrue: true
 stringfalse: 'false'
+stringtrue: 'true'
 ...
 
 
@@ -19,7 +20,7 @@ if ($@ and $@ =~ m{boolean}) {
     exit;
 }
 
-plan tests => 5;
+plan tests => 7;
 
 local $YAML::XS::Boolean = "boolean";
 isa_ok($hash->{booltrue}, 'boolean');
@@ -27,6 +28,9 @@ isa_ok($hash->{boolfalse}, 'boolean');
 
 cmp_ok($hash->{booltrue}, '==', 1, "boolean true is true");
 cmp_ok($hash->{boolfalse}, '==', 0, "boolean false is false");
+
+ok(! ref $hash->{stringtrue}, "string 'true' stays string");
+ok(! ref $hash->{stringfalse}, "string 'false' stays string");
 
 my $yaml2 = Dump($hash);
 cmp_ok($yaml2, 'eq', $yaml, "Roundtrip booleans ok");

--- a/test/boolean-boolean.t
+++ b/test/boolean-boolean.t
@@ -2,7 +2,7 @@ use FindBin '$Bin';
 use lib $Bin;
 use TestYAMLTests;
 
-local $YAML::XS::Boolean = "JSON::PP";
+local $YAML::XS::Boolean = "boolean";
 
 my $yaml = <<'...';
 ---
@@ -14,15 +14,16 @@ stringfalse: 'false'
 
 my $hash = eval { Load $yaml };
 
-if ($@ and $@ =~ m{JSON/PP}) {
-    plan skip_all => "JSON::PP not installed";
+if ($@ and $@ =~ m{boolean}) {
+    plan skip_all => "boolean not installed";
     exit;
 }
 
 plan tests => 5;
 
-isa_ok($hash->{booltrue}, 'JSON::PP::Boolean');
-isa_ok($hash->{boolfalse}, 'JSON::PP::Boolean');
+local $YAML::XS::Boolean = "boolean";
+isa_ok($hash->{booltrue}, 'boolean');
+isa_ok($hash->{boolfalse}, 'boolean');
 
 cmp_ok($hash->{booltrue}, '==', 1, "boolean true is true");
 cmp_ok($hash->{boolfalse}, '==', 0, "boolean false is false");

--- a/test/boolean-invalid.t
+++ b/test/boolean-invalid.t
@@ -1,0 +1,36 @@
+use FindBin '$Bin';
+use lib $Bin;
+use TestYAMLTests;
+
+my @disable = (['int 0', 0], ['string 0', '0'], ['empty string', ''], ['undef', undef]);
+my @invalid = (['int 1', 1], ['string 1', '1'], ['string foo', 'foo']);
+my $tests = (@disable + 2 * @invalid);
+plan tests => $tests;
+
+for (@invalid) {
+    my ($label, $test) = @$_;
+    local $YAML::XS::Boolean = $test;
+
+    my $data = eval { Load "dummy" };
+#    $@ and diag "ERROR: $@";
+    cmp_ok($@, '=~', qr{accepts}, "YAML::XS::Load: $label is an invalid setting");
+
+    my $yaml = eval { Dump { foo => 42 } };
+#    $@ and diag "ERROR: $@";
+    cmp_ok($@, '=~', qr{accepts}, "YAML::XS::Dump: $label is an invalid setting");
+}
+
+for (@disable) {
+    my ($label, $test) = @$_;
+    local $YAML::XS::Boolean = $test;
+
+    my $data = eval { Load "true" };
+    if ($@) {
+        diag "ERROR: $@";
+        ok(0, "$label disables YAML::XS::Boolean");
+    }
+    else {
+        my $ref = ref $data;
+        cmp_ok($ref, 'eq', '', "$label disables YAML::XS::Boolean");
+    }
+}

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -3,15 +3,6 @@ use lib $Bin;
 use TestYAMLTests;
 
 local $YAML::XS::Booleans = 1;
-my $jsonpp = eval {
-    require JSON::PP;
-    1;
-};
-unless ($jsonpp) {
-    plan skip_all => "JSON::PP not installed";
-    exit;
-}
-plan tests => 5;
 
 my $yaml = <<'...';
 ---
@@ -20,7 +11,14 @@ booltrue: true
 stringfalse: 'false'
 ...
 
-my $hash = Load $yaml;
+
+my $hash = eval { Load $yaml };
+if ($@ and $@ =~ m/JSON::PP/) {
+    plan skip_all => "JSON::PP not installed";
+    exit;
+}
+
+plan tests => 5;
 
 isa_ok($hash->{booltrue}, 'JSON::PP::Boolean',
     "boolean true loads as JSON::PP::Boolean");

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -2,7 +2,7 @@ use FindBin '$Bin';
 use lib $Bin;
 use TestYAMLTests;
 
-local $YAML::XS::Booleans = 1;
+local $YAML::XS::Boolean = 1;
 
 my $yaml = <<'...';
 ---

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -13,7 +13,7 @@ stringfalse: 'false'
 
 
 my $hash = eval { Load $yaml };
-if ($@ and $@ =~ m/JSON::PP/) {
+if ($@ and $@ =~ m{JSON/PP}) {
     plan skip_all => "JSON::PP not installed";
     exit;
 }

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -9,6 +9,7 @@ my $yaml = <<'...';
 boolfalse: false
 booltrue: true
 stringfalse: 'false'
+stringtrue: 'true'
 ...
 
 
@@ -19,13 +20,16 @@ if ($@ and $@ =~ m{JSON/PP}) {
     exit;
 }
 
-plan tests => 5;
+plan tests => 7;
 
 isa_ok($hash->{booltrue}, 'JSON::PP::Boolean');
 isa_ok($hash->{boolfalse}, 'JSON::PP::Boolean');
 
 cmp_ok($hash->{booltrue}, '==', 1, "boolean true is true");
 cmp_ok($hash->{boolfalse}, '==', 0, "boolean false is false");
+
+ok(! ref $hash->{stringtrue}, "string 'true' stays string");
+ok(! ref $hash->{stringfalse}, "string 'false' stays string");
 
 my $yaml2 = Dump($hash);
 cmp_ok($yaml2, 'eq', $yaml, "Roundtrip booleans ok");

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -4,11 +4,11 @@ use TestYAMLTests;
 
 local $YAML::XS::Booleans = 1;
 my $jsonpp = eval {
-    require JSON::PP::Boolean;
+    require JSON::PP;
     1;
 };
 unless ($jsonpp) {
-    plan skip_all => "JSON::PP::Boolean not installed";
+    plan skip_all => "JSON::PP not installed";
     exit;
 }
 plan tests => 5;

--- a/test/boolean-jsonpp.t
+++ b/test/boolean-jsonpp.t
@@ -1,0 +1,35 @@
+use FindBin '$Bin';
+use lib $Bin;
+use TestYAMLTests;
+
+local $YAML::XS::Booleans = 1;
+my $jsonpp = eval {
+    require JSON::PP::Boolean;
+    1;
+};
+unless ($jsonpp) {
+    plan skip_all => "JSON::PP::Boolean not installed";
+    exit;
+}
+plan tests => 5;
+
+my $yaml = <<'...';
+---
+boolfalse: false
+booltrue: true
+stringfalse: 'false'
+...
+
+my $hash = Load $yaml;
+
+isa_ok($hash->{booltrue}, 'JSON::PP::Boolean',
+    "boolean true loads as JSON::PP::Boolean");
+cmp_ok($hash->{booltrue}, '==', 1, "boolean true is true");
+
+isa_ok($hash->{boolfalse}, 'JSON::PP::Boolean',
+    "boolean false loads as JSON::PP::Boolean");
+cmp_ok($hash->{boolfalse}, '==', 0, "boolean false is false");
+
+my $yaml2 = Dump($hash);
+cmp_ok($yaml2, 'eq', $yaml, "Roundtrip booleans ok");
+


### PR DESCRIPTION
When `$YAML::XS::Booleans` is true, it will load and dump `JSON::PP::Boolean`
objects.

~~Currently, you have to load JSON::PP yourself. This should be done in XS, too.~~

Edit: JSON::PP will be loaded automatically now.

