### PR TITLE
Fix error (corrupted stack) when loading regexes

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -513,6 +513,10 @@ load_regexp(perl_yaml_loader_t * loader)
     SPAGAIN;
     regexp = newSVsv(POPs);
 
+    PUTBACK;
+    FREETMPS;
+    LEAVE;
+
     if (strlen(tag) > strlen(prefix) && strnEQ(tag, prefix, strlen(prefix))) {
         char *class = tag + strlen(prefix);
         sv_bless(regexp, gv_stashpv(class, TRUE));


### PR DESCRIPTION
Error was: panic: memory wrap

This is a fix for issue #64

See perldoc perlcall

