### PR TITLE
ability to use system-wide libyaml (when the bundled one is gone)

### DIFF
--- a/LibYAML/Makefile.PL
+++ b/LibYAML/Makefile.PL
@@ -24,7 +24,7 @@ WriteMakefile(
     # CCFLAGS => '-pedantic -Wall',
     # CCFLAGS => '-Wall',
     DEFINE => $DEFINE,
-    LIBS => [''], # e.g., '-lm'
+    LIBS => [$ENV{USE_SYSTEM_LIBYAML} ? '-lyaml' : ()], # e.g., '-lm'
     INC => '-I.',
     OBJECT => $obj_files,
     ABSTRACT_FROM => 'lib/YAML/XS/LibYAML.pm',

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -767,6 +767,8 @@ dump_document(perl_yaml_dumper_t *dumper, SV *node)
     yaml_emitter_emit(&dumper->emitter, &event_document_start);
     dump_node(dumper, node);
     yaml_document_end_event_initialize(&event_document_end, 1);
+    // suppress end-of-document marker ('...')
+    dumper->emitter.open_ended = 0;
     yaml_emitter_emit(&dumper->emitter, &event_document_end);
 }
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
YAML-LibYAML.
We thought you might be interested in it too.

    Description: ability to use system-wide libyaml
     Link with libyaml when USE_SYSTEM_LIBYAML is present in the environment.
     .
     This probably needs more work like moving bundled libyaml in a subdirectory
     and recurse in it only if needed, but this patch is useful for Debian as it
     is, because it allows us to strip the bindled libyaml from the sources and
     link with the system-wide libyaml.
     .
     The open_ended=0 setting is there to prevent libyaml from appending document
     end marker ('...') when dumping. It is optional according to the spec and its
     presense breaks a couple of tests.
    Author: Damyan Ivanov <dmn@debian.org>
    Bug: https://github.com/ingydotnet/yaml-libyaml-pm/issues/49
    Bug-Debian: https://bugs.debian.org/664224

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libyaml-libyaml-perl.git/plain/debian/patches/system-libyaml.patch

Thanks for considering,
  Damyan Ivanov,
  Debian Perl Group
