### PR TITLE
Fix memleaks when loading invalid YAML

### DIFF
--- a/note/memleak.pl
+++ b/note/memleak.pl
@@ -11,7 +11,7 @@ sub yaml {
         my $obj = Load($str);
     };
     if ($@) {
-        say "EVAL_ERROR: $@\nfailed to convert YAML string: $str";
+#        say "EVAL_ERROR: $@\nfailed to convert YAML string: $str";
     }
 }
 
@@ -19,19 +19,50 @@ my $str = do { local $/; <DATA> };
 
 my $count = $ARGV[0] || 1000;
 my $sleep = $ARGV[1] || 3;
+my $m1 = mem();
+
 for my $i (0 .. $count) {
-    say "== Loop $i";
-    select undef, undef, undef, 0.005;
+    select undef, undef, undef, $sleep;
     yaml($str);
 
-    if ($i and not $i % 50) {
-        say "Process size:";
-        system("ps -o pid,vsz --pid $$");
-        select undef, undef, undef, $sleep;
-    }
 }
+my $m2 = mem();
+say $m2 - $m1;
+
+sub mem {
+    chomp(my $mem = qx{ps --no-headers -o vsize:3 --pid $$});
+    say "Mem: $mem";
+    return $mem;
+}
+
+=pod
+
+=over
+
+=item Mappings
+
+    ---
+    foo: [[[[[[[[[[bar]]]]]]]]]]
+    aaa
+
+
+    ---
+    - {{{{{{{{{{
+
+=item Sequences
+
+    ---
+    - [[[[[[[[[[foo]]]]]]]]]]
+    - @error
+
+    ---
+    - [[[[[[[[[[
+
+=back
+
+=cut
 
 __DATA__
 ---
-foo: bar
+foo: [[[[[[[[[[bar]]]]]]]]]]
 aaa


### PR DESCRIPTION
When loading invalid YAML, SVs already created weren't destroyed.

See note/memleak.pl for examples

See also related #48