### PR TITLE
Add configuration for line width of Dump()

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -624,12 +624,13 @@ load_code(perl_yaml_loader_t * loader)
     char *anchor = (char *)loader->event.data.scalar.anchor;
     char *tag = (char *)loader->event.data.scalar.tag;
     char *prefix = TAG_PERL_PREFIX "code:";
+    SV *code;
 
     if (! loader->load_code) {
         string = "{}";
         length = 2;
     }
-    SV *code = newSVpvn(string, length);
+    code = newSVpvn(string, length);
     SvUTF8_on(code);
 
 
@@ -760,6 +761,7 @@ Dump(SV *dummy, ...)
     yaml_event_t event_stream_end;
     int i;
     SV *yaml = sv_2mortal(newSVpvn("", 0));
+    SV *indent, *width;
     sp = mark;
 
     set_dumper_options(&dumper);
@@ -768,11 +770,15 @@ Dump(SV *dummy, ...)
     yaml_emitter_initialize(&dumper.emitter);
 
     /* set indent */
-    SV* indent = get_sv("YAML::XS::Indent", GV_ADD);
+    indent = get_sv("YAML::XS::Indent", GV_ADD);
     if (SvIOK(indent)) yaml_emitter_set_indent(&dumper.emitter, SvIV(indent));
 
     yaml_emitter_set_unicode(&dumper.emitter, 1);
-    yaml_emitter_set_width(&dumper.emitter, 2);
+
+    /* set width */
+    width = get_sv("YAML::XS::Width", GV_ADD);
+    yaml_emitter_set_width(&dumper.emitter, SvIOK(width) ? SvIV(width) : 2);
+
     yaml_emitter_set_output(
         &dumper.emitter,
         &append_output,

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -110,6 +110,12 @@ functions. Only `Load` and `Dump` are exported by default.
 
   Sets the number of spaces for indentation for `Dump`.
 
+- `$YAML::XS::Width` (since v0.84)
+
+  Default is 80.
+
+  Sets the approximate line width for `Dump`. A negative value suppresses the
+  line wrapping.
 
 = Using YAML::XS with Unicode
 

--- a/test/width.t
+++ b/test/width.t
@@ -1,0 +1,105 @@
+use FindBin '$Bin';
+use lib $Bin;
+use TestYAMLTests tests => 5;
+
+my @a = split /\s+/, 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sed sagittis nisi, 
+vitae elementum est. Vestibulum interdum eros ut neque viverra, aliquet euismod justo aliquam. Mauris
+nibh nibh, scelerisque id velit eu, cursus pharetra nisi. Maecenas at tortor ac eros auctor euismod
+nec id sapien. Donec eu faucibus nunc. Phasellus sagittis varius nibh a dapibus.';
+
+sub _ {join ' ', @a[@_]}
+sub ___ {
+  is Dump([{_(0,1)=>_(2..14),_(15)=>{_(16)=>_(17..24),_(25..27)=>{_(26)=>_(27..44),_(45,46)=>_(47,48),_(49)=>_(50..54)}}}]),
+  $_[1], 'Dumped with width ' . $_[0]
+}
+
+___('undef', <<'xxx'); # default of libyaml is 80
+---
+- Lorem ipsum: dolor sit amet, consectetur adipiscing elit. Nunc sed sagittis nisi,
+    vitae elementum est.
+  Vestibulum:
+    Mauris nibh nibh,:
+      Donec eu: faucibus nunc.
+      Phasellus: sagittis varius nibh a dapibus.
+      nibh: nibh, scelerisque id velit eu, cursus pharetra nisi. Maecenas at tortor
+        ac eros auctor euismod nec id sapien.
+    interdum: eros ut neque viverra, aliquet euismod justo aliquam.
+xxx
+
+___(1, <<'xxx'); # width <= 2* indent is changed to default in libyaml
+---
+- Lorem ipsum: dolor sit amet, consectetur adipiscing elit. Nunc sed sagittis nisi,
+    vitae elementum est.
+  Vestibulum:
+    Mauris nibh nibh,:
+      Donec eu: faucibus nunc.
+      Phasellus: sagittis varius nibh a dapibus.
+      nibh: nibh, scelerisque id velit eu, cursus pharetra nisi. Maecenas at tortor
+        ac eros auctor euismod nec id sapien.
+    interdum: eros ut neque viverra, aliquet euismod justo aliquam.
+xxx
+
+___($YAML::XS::Width = -1, <<'xxx');
+---
+- Lorem ipsum: dolor sit amet, consectetur adipiscing elit. Nunc sed sagittis nisi, vitae elementum est.
+  Vestibulum:
+    Mauris nibh nibh,:
+      Donec eu: faucibus nunc.
+      Phasellus: sagittis varius nibh a dapibus.
+      nibh: nibh, scelerisque id velit eu, cursus pharetra nisi. Maecenas at tortor ac eros auctor euismod nec id sapien.
+    interdum: eros ut neque viverra, aliquet euismod justo aliquam.
+xxx
+
+___($YAML::XS::Width = 60, <<'xxx');
+---
+- Lorem ipsum: dolor sit amet, consectetur adipiscing elit. Nunc
+    sed sagittis nisi, vitae elementum est.
+  Vestibulum:
+    Mauris nibh nibh,:
+      Donec eu: faucibus nunc.
+      Phasellus: sagittis varius nibh a dapibus.
+      nibh: nibh, scelerisque id velit eu, cursus pharetra nisi.
+        Maecenas at tortor ac eros auctor euismod nec id sapien.
+    interdum: eros ut neque viverra, aliquet euismod justo aliquam.
+xxx
+___($YAML::XS::Width = 10, <<'xxx');
+---
+- Lorem ipsum: dolor
+    sit amet,
+    consectetur
+    adipiscing
+    elit. Nunc
+    sed sagittis
+    nisi, vitae
+    elementum
+    est.
+  Vestibulum:
+    Mauris nibh nibh,:
+      Donec eu: faucibus
+        nunc.
+      Phasellus: sagittis
+        varius
+        nibh
+        a dapibus.
+      nibh: nibh,
+        scelerisque
+        id velit
+        eu,
+        cursus
+        pharetra
+        nisi.
+        Maecenas
+        at tortor
+        ac eros
+        auctor
+        euismod
+        nec
+        id sapien.
+    interdum: eros
+      ut neque
+      viverra,
+      aliquet
+      euismod
+      justo
+      aliquam.
+xxx


### PR DESCRIPTION
- Use global variable $YAML::XS::Width to set the line width of Dump().
- Relocate local variable declarations in perl_libyaml.c to make it compilable
  by a legacy C/C++ compiler (MS VC6).