### PR TITLE
Add option ForbidDuplicateKeys

### DIFF
--- a/LibYAML/perl_libyaml.h
+++ b/LibYAML/perl_libyaml.h
@@ -32,6 +32,7 @@ typedef struct {
     int load_bool_jsonpp;
     int load_bool_boolean;
     int load_blessed;
+    int forbid_duplicate_keys;
     int document;
 } perl_yaml_loader_t;
 

--- a/doc/YAML/XS.swim
+++ b/doc/YAML/XS.swim
@@ -51,6 +51,21 @@ functions. Only `Load` and `Dump` are exported by default.
   the object is deleted. An example with File::Temp removing files can be found
   at [https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=862373]
 
+- $YAML::XS::ForbidDuplicateKeys` (since 0.84)
+
+  Default: false
+
+  When set to true, `Load` will die when encountering a duplicate key in a hash,
+  e.g.
+
+    key: value
+    key: another value
+
+  This can be useful for bigger YAML documents where it is not that obvious,
+  and it is recommended to set it to true.
+  That's also what a YAML loader should do by default according to the YAML
+  specification.
+
 - `$YAML::XS::UseCode`
 
 - `$YAML::XS::DumpCode`

--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -10,7 +10,16 @@ use base 'Exporter';
 %YAML::XS::EXPORT_TAGS = (
     all => [qw(Dump Load LoadFile DumpFile)],
 );
-our ($UseCode, $DumpCode, $LoadCode, $Boolean, $LoadBlessed, $Indent);
+our (
+    $Boolean,
+    $DumpCode,
+    $ForbidDuplicateKeys,
+    $Indent,
+    $LoadBlessed,
+    $LoadCode,
+    $UseCode,
+);
+$ForbidDuplicateKeys = 0;
 # $YAML::XS::UseCode = 0;
 # $YAML::XS::DumpCode = 0;
 # $YAML::XS::LoadCode = 0;

--- a/test/duplicate-keys.t
+++ b/test/duplicate-keys.t
@@ -1,0 +1,22 @@
+use FindBin '$Bin';
+use lib $Bin;
+use TestYAMLTests;
+
+plan tests => 3;
+
+my $yaml = <<'...';
+key: value
+key: another value
+...
+
+my $hash = Load $yaml;
+is_deeply $hash, { key => 'another value' }, 'Allow duplicate keys (default)';
+
+$YAML::XS::ForbidDuplicateKeys = 0;
+$hash = Load $yaml;
+is_deeply $hash, { key => 'another value' }, 'Allow duplicate keys explicitly';
+
+$YAML::XS::ForbidDuplicateKeys = 1;
+$hash = eval { Load $yaml };
+my $err = $@;
+like $err, qr{Duplicate key 'key'}, 'Forbid duplicate keys';


### PR DESCRIPTION
By default it is false as it could suddenly break code.

See issue #17

YAML::PP forbids duplicate keys by default, according to the YAML Spec.

