### PR TITLE
Turn off POK for numbers

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,7 +2,7 @@
 version: 0.86_001
 date:    Thu May  4 12:46:22 PM CEST 2023
 changes:
-- Turn off interal POK flag for number scalars
+- Turn off internal POK flag for number scalars
 ---
 version: 0.86
 date:    Wed Jan 25 09:34:14 PM EST 2023

--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
 ---
+version: 0.86_001
+date:    Thu May  4 12:46:22 PM CEST 2023
+changes:
+- Turn off interal POK flag for number scalars
+---
 version: 0.86
 date:    Wed Jan 25 09:34:14 PM EST 2023
 changes:

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -575,7 +575,12 @@ load_scalar(perl_yaml_loader_t *loader)
 
     if (style == YAML_PLAIN_SCALAR_STYLE && looks_like_number(scalar) ) {
         /* numify */
-        SvIV_please(scalar);
+        if (SvNV(scalar) == SvIV(scalar)) {
+            SvIOK_only(scalar);
+        }
+        else {
+            SvNOK_only(scalar);
+        }
     }
 
     (void)sv_utf8_decode(scalar);

--- a/Meta
+++ b/Meta
@@ -1,7 +1,7 @@
 =meta: 0.0.2
 
 name: YAML-LibYAML
-version: 0.86
+version: 0.86_001
 abstract: Perl YAML Serialization using XS and libyaml
 homepage: http://yaml.org
 language: perl

--- a/lib/YAML/LibYAML.pm
+++ b/lib/YAML/LibYAML.pm
@@ -1,6 +1,6 @@
 use strict; use warnings;
 package YAML::LibYAML;
-our $VERSION = '0.86';
+our $VERSION = '0.86_001';
 
 sub import {
     die "YAML::LibYAML has been renamed to YAML::XS. Please use YAML::XS instead.";

--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -1,7 +1,7 @@
 use strict; use warnings;
 
 package YAML::XS;
-our $VERSION = '0.86';
+our $VERSION = '0.86_001';
 
 use base 'Exporter';
 


### PR DESCRIPTION
Fix for #68

Using @perlpunk 's test code:
```
use v5.16;
use YAML::XS qw/ Load /;
use JSON::PP qw/ encode_json /;
use Devel::Peek qw/ Dump /;
my $yaml = "foo: 23";
my $data = Load $yaml;
my $json = encode_json($data);
say $json;
Dump $data->{foo};
```
before:
```
{"foo":23}
SV = PVIV(0x556868e926c8) at 0x556868e8b130
  REFCNT = 1
  FLAGS = (IOK,POK,pIOK,pPOK)
  IV = 23
  PV = 0x556869234380 "23"\0
  CUR = 2
  LEN = 10
```
after:
```
{"foo":23}
SV = PVNV(0x55a2dce90580) at 0x55a2dcead130
  REFCNT = 1
  FLAGS = (IOK,pIOK)
  IV = 23
  NV = 23
  PV = 0x55a2dd255c90 "23"\0
  CUR = 2
  LEN = 10
```
Note that `POK` is now turned off, though `pIOK` remains as does the `PV`.

Also the JSON number was not quoted on my machine.

@karenetheridge can you test if this fixes your issue?