### PR TITLE
Recognise core booleans on Perl 5.36+ at dump time (Fixes #113)

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -1,5 +1,9 @@
 #include <perl_libyaml.h>
 
+#if (PERL_REVISION > 5) || (PERL_REVISION == 5 && PERL_VERSION >= 36)
+#  define PERL_HAVE_BOOLEANS
+#endif
+
 static SV *
 call_coderef(SV *code, AV *args)
 {
@@ -1152,12 +1156,20 @@ dump_scalar(perl_yaml_dumper_t *dumper, SV *node, yaml_char_t *tag)
         string_len = 1;
         style = YAML_PLAIN_SCALAR_STYLE;
     }
-    else if (node == &PL_sv_yes) {
+    else if (node == &PL_sv_yes
+#ifdef PERL_HAVE_BOOLEANS
+        || (SvIsBOOL(node) && SvTRUE(node))
+#endif
+    ) {
         string = "true";
         string_len = 4;
         style = YAML_PLAIN_SCALAR_STYLE;
     }
-    else if (node == &PL_sv_no) {
+    else if (node == &PL_sv_no
+#ifdef PERL_HAVE_BOOLEANS
+        || (SvIsBOOL(node) && !SvTRUE(node))
+#endif
+    ) {
         string = "false";
         string_len = 5;
         style = YAML_PLAIN_SCALAR_STYLE;

--- a/test/boolean.t
+++ b/test/boolean.t
@@ -1,7 +1,7 @@
 use FindBin '$Bin';
 use lib $Bin;
 use constant HAVE_BOOLEANS => ($^V ge v5.36);
-use TestYAMLTests tests => 5 + (HAVE_BOOLEANS ? 1 : 0);
+use TestYAMLTests tests => 5 + (HAVE_BOOLEANS ? 2 : 0);
 
 my $yaml = <<'...';
 ---
@@ -51,4 +51,11 @@ if( HAVE_BOOLEANS ) {
 'true': true
 ...
         'core booleans dump as booleans';
+
+    ok builtin::is_bool(Load(<<'...',)->{false}),
+---
+'false': false
+'true': true
+...
+        'booleans loaded as core booleans';
 }

--- a/test/boolean.t
+++ b/test/boolean.t
@@ -1,6 +1,7 @@
 use FindBin '$Bin';
 use lib $Bin;
-use TestYAMLTests tests => 5;
+use constant HAVE_BOOLEANS => ($^V ge v5.36);
+use TestYAMLTests tests => 5 + (HAVE_BOOLEANS ? 1 : 0);
 
 my $yaml = <<'...';
 ---
@@ -39,3 +40,15 @@ my $yaml4 = Dump Load $yaml3;
 
 is $yaml4, $yaml3,
     "Everything related to boolean YNY roundtrips";
+
+if( HAVE_BOOLEANS ) {
+    no if HAVE_BOOLEANS, warnings => "experimental::builtin";
+
+    is Dump({ true => builtin::true, false => builtin::false }),
+        <<'...',
+---
+'false': false
+'true': true
+...
+        'core booleans dump as booleans';
+}


### PR DESCRIPTION
Unsure if you'll be happy with the exact layout and formatting of this, but this is the basic idea.