### PR TITLE
Do not set loaded booleans to readonly for perl >= v5.36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 /cpan/
 /YAML-LibYAML*
+/LibYAML/*.o
+/LibYAML/*.bs
+/LibYAML/LibYAML.c
+/LibYAML/MYMETA.json
+/LibYAML/MYMETA.yml
+/LibYAML/Makefile
+/LibYAML/pm_to_blib
+/pm_to_blib
+/blib
+/MYMETA.json
+/MYMETA.yml
+/Makefile

--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -549,7 +549,11 @@ load_scalar(perl_yaml_loader_t *loader)
                 scalar = sv_setref_iv(scalar, name, 1);
             }
             else {
+#ifdef PERL_HAVE_BOOLEANS
+                scalar = newSVsv(&PL_sv_yes);
+#else
                 scalar = &PL_sv_yes;
+#endif
             }
             if (anchor)
                 hv_store(loader->anchors, anchor, strlen(anchor), SvREFCNT_inc(scalar), 0);
@@ -567,7 +571,11 @@ load_scalar(perl_yaml_loader_t *loader)
                 scalar = sv_setref_iv(scalar, name, 0);
             }
             else {
+#ifdef PERL_HAVE_BOOLEANS
+                scalar = newSVsv(&PL_sv_no);
+#else
                 scalar = &PL_sv_no;
+#endif
             }
             if (anchor)
                 hv_store(loader->anchors, anchor, strlen(anchor), SvREFCNT_inc(scalar), 0);

--- a/lib/YAML/XS.pod
+++ b/lib/YAML/XS.pod
@@ -80,10 +80,12 @@ This ensures leading that things like leading zeros and other formatting are pre
 
 Default: undef
 
-When used with perl 5.36 or later, builtin booleans will work out of the box. They will be created by C<Load> and recognized by C<Dump> automatically (since YAML::XS 0.89).
+Since YAML::XS 0.89: When used with perl 5.36 or later, builtin booleans will work out of the box. They will be created by C<Load> and recognized by C<Dump> automatically (since YAML::XS 0.89).
 
     say Dump({ truth => builtin::true });
     # truth: true
+
+Since YAML::XS v0.902: loaded booleans are not set to readonly anymore.
 
 For older perl versions you can use the following configuration to serialize data as YAML booleans:
 

--- a/t/boolean.t
+++ b/t/boolean.t
@@ -1,7 +1,7 @@
 use FindBin '$Bin';
 use lib $Bin;
 use constant HAVE_BOOLEANS => ($^V ge v5.36);
-use TestYAMLTests tests => 5 + (HAVE_BOOLEANS ? 2 : 0);
+use TestYAMLTests tests => 5 + (HAVE_BOOLEANS ? 4 : 0);
 
 my $yaml = <<'...';
 ---
@@ -58,4 +58,8 @@ if( HAVE_BOOLEANS ) {
 'true': true
 ...
         'booleans loaded as core booleans';
+
+    eval { $hash->{a} = 'something else' };
+    is $@, '', "core boolean element in hash is not readonly";
+    is $hash->{a}, 'something else', "core boolean element is changed";
 }

--- a/t/file.t
+++ b/t/file.t
@@ -31,3 +31,7 @@ YAML::XS::DumpFile($test_file, $t3, $t4);
 my ($t3_, $t4_) = LoadFile($test_file);
 
 is_deeply [$t3_, $t4_], [$t3, $t4], 'Unicode roundtrip ok';
+
+END {
+    rmtree('t/output');
+}


### PR DESCRIPTION
Since perl 5.36, PL_sv_yes/PL_sv_no will be preserved as booleans
automatically. If we create them with newSVsv(), they are not readonly
anymore and will still roundtrip.
