### PR TITLE
Use 3-arg form of open in LoadFile

### DIFF
--- a/lib/YAML/XS.pm
+++ b/lib/YAML/XS.pm
@@ -54,7 +54,7 @@ sub LoadFile {
         $IN = $filename;
     }
     else {
-        open $IN, $filename
+        open $IN, '<', $filename
           or die "Can't open '$filename' for input:\n$!";
     }
     return YAML::XS::LibYAML::Load(do { local $/; local $_ = <$IN> });


### PR DESCRIPTION
Fixes https://github.com/ingydotnet/yaml-libyaml-pm/issues/120

Otherwise `$filename = ">file.yaml"; LoadFile($filename)` will truncate a file.

One should check untrusted filenames in any case, though.