### PR TITLE
fix: Improve handling of mapping keys (OOP interface)

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -1674,7 +1674,6 @@ oo_load_mapping(perl_yaml_xs_t *self)
             if (!SvOK(key_node)) {
                 sv_setpvn(key_node, "", 0);
             }
-            assert(SvPOK(key_node));
             value_node = oo_load_node(self);
             if ( /* self->forbid_duplicate_keys && */
                 hv_exists_ent(hash, key_node, 0)
@@ -1687,9 +1686,9 @@ oo_load_mapping(perl_yaml_xs_t *self)
                     )
                 );
             }
-            hv_store_ent(
-                hash, sv_2mortal(key_node), value_node, 0
-            );
+            if (!hv_store_ent(hash, key_node, value_node, 0))
+                SvREFCNT_dec(value_node);
+            SvREFCNT_dec(key_node);
         }
 
         /* If cyclic refs are forbidden, we only add the anchor after

--- a/t/oop/10-basic.t
+++ b/t/oop/10-basic.t
@@ -8,23 +8,26 @@ my $xs = YAML::XS->new;
 is ref $xs, 'YAML::XS', "got YAML::XS object";
 
 my $yaml = <<'EOM';
+seq:
 - foo
 - [bar]
-- key: val
+map:
+  key: val
+  200: number as key works
+  null: undef as key -> empty string
 ---
 foo: bar
 EOM
 
-
-my @exp = (
-    foo => ['bar'], { key => 'val' }
-);
+my $exp = {
+   seq => [ foo => ['bar'] ],
+   map => { key => 'val',  200 => 'number as key works', '' => 'undef as key -> empty string' }
+};
 my $data = $xs->load($yaml);
-is_deeply $data, \@exp, 'load scalar context';
-
+is_deeply $data, $exp, 'load scalar context';
 
 my @data = $xs->load($yaml);
-is_deeply $data[0], \@exp, 'load list context, first document';
+is_deeply $data[0], $exp, 'load list context, first document';
 is_deeply $data[1], { foo => 'bar' }, 'load list context, second document';
 
 @data = $xs->load('foo: bar');


### PR DESCRIPTION
The `assert` caused an error under a perl with DEBUGGING enabled, when loading a mapping with a number as a key.

It is actually not necessary anymore, because we explicitly set the key to the empty string if it's undef.

Additionally, Gemini suggested to `SvREFCNT_dec` explicitly instead of using `sv_2mortal`, as `sv_2mortal` has some overhead and will only free the memory when XS returns to perl.