### PR TITLE
include a version in YAML::XS::LibYAML

### DIFF
--- a/LibYAML/Makefile.PL
+++ b/LibYAML/Makefile.PL
@@ -30,5 +30,6 @@ WriteMakefile(
     INC => '-I.',
     OBJECT => $obj_files,
     ABSTRACT_FROM => 'lib/YAML/XS/LibYAML.pm',
+    VERSION_FROM => 'lib/YAML/XS/LibYAML.pm',
     AUTHOR => 'Ingy döt Net <ingy@cpan.org>',
 );

--- a/LibYAML/lib/YAML/XS/LibYAML.pm
+++ b/LibYAML/lib/YAML/XS/LibYAML.pm
@@ -3,6 +3,8 @@ use 5.008001;
 use strict;
 use warnings;
 
+our $VERSION = '0.000'; # VERSION
+
 use XSLoader;
 XSLoader::load 'YAML::XS::LibYAML';
 use base 'Exporter';

--- a/dist.ini
+++ b/dist.ini
@@ -15,8 +15,17 @@ exclude_filename = ReadMe.md
 [Manifest]
 [ManifestSkip]
 [MetaYAML]
+
+[FileFinder::ByName / ModuleFinder]
+dir   = lib
+dir   = LibYAML/lib
+file  = *.pm
+
 [OverridePkgVersion]
+finder = ModuleFinder
 [MetaProvides::Package]
+finder = ModuleFinder
+
 [License]
 [ExtraTests]
 [ExecDir]


### PR DESCRIPTION
Add a VERSION to YAML::XS::LibYAML. This requires updating the Dist::Zilla configuration to be able to find the module for setting the version as well as adding it to provides.