### PR TITLE
Fix for quadmath builds of perl

### DIFF
--- a/LibYAML/perl_libyaml.c
+++ b/LibYAML/perl_libyaml.c
@@ -2059,12 +2059,12 @@ oo_dump_scalar(perl_yaml_xs_t *self, SV *node)
             string_len = 5;
             style = YAML_PLAIN_SCALAR_STYLE;
         }
-        else if (isnan(val)) {
+        else if (Perl_isnan(val)) {
             string = ".nan";
             string_len = 4;
             style = YAML_PLAIN_SCALAR_STYLE;
         }
-        else if (isinf(val)) {
+        else if (Perl_isinf(val)) {
             if (val == -NV_INF) {
                 string = "-.inf";
                 string_len = 5;


### PR DESCRIPTION
Fixes https://github.com/ingydotnet/yaml-libyaml-pm/issues/129.

At https://github.com/Perl/perl5/issues/24472 I provided a patch to perl.h (in perl source) that would address #129 for Windows.
The discussion in https://github.com/Perl/perl5/issues/24472  points to various inadequacies in that approach, with Tony Cook stating "Looking at the yaml ticket, that looks like a module bug, it should be using the Perl_ prefix functions to get quadmath support" and "YAML::LibYAML needs to fix their code, or they can just not support quadmath".

This PR provides that support, for Windows at least.