### PR TITLE
Fix application crash on missing JSON::PP dependency

### DIFF
--- a/t/oop/13-utf8.t
+++ b/t/oop/13-utf8.t
@@ -44,7 +44,7 @@ note "---> $yaml";
     $ENV{TEST_VERBOSE} and Dump $yaml;
 
 }
-if (require JSON::PP) {
+if (eval {require JSON::PP; 1}) {
     my $j = JSON::PP->new;
     my $ju = JSON::PP->new->utf8;
     my ($json, $data);


### PR DESCRIPTION
Safely check for JSON::PP availability without crashing if it is missing.

Recreated #128 because there were no CI checks for some reason